### PR TITLE
revise a note of promise then.

### DIFF
--- a/open-in-web-browser.html
+++ b/open-in-web-browser.html
@@ -3829,7 +3829,7 @@ myPromise.then((data)=>{
         <strong>Notes:</strong>
     </p>
     <ol>
-        <li>If you don't provide <code>then()</code> a resolve function or provide a non-function, no error will occur. The next <code>then()</code> resolve function is passed an <code>undefined</code> value.</li>
+        <li>If you don't provide <code>then()</code> a resolve function or provide a non-function, no error will occur, and the next <code>then()</code> resolve function will passed the value the current resolve function passed.</li>
     </ol>
 </div>
 


### PR DESCRIPTION
I'm not sure if I misunderstood this note. According to: 

https://tc39.es/ecma262/#sec-performpromisethen

>Else if promise.[[PromiseState]] is fulfilled, then
>---Let value be promise.[[PromiseResult]].
>---Let fulfillJob be NewPromiseReactionJob(fulfillReaction, value).

https://tc39.es/ecma262/#sec-newpromisereactionjob

> If handler is undefined, then
> ---If type is Fulfill, let handlerResult be NormalCompletion(argument).

if you don't provide then() a non-function, the next then() resolve function will passed the value the current resolve function passed.

eg: 

```js
> Promise.resolve(42).then(24).then(d => console.log(d))
// 42

> Promise.resolve(42).then({}, ()=>{}).then(d => console.log(d))
// 42

> Promise.resolve(42).then().then(d => console.log(d))
// 42
```